### PR TITLE
Add command completion on enter (like vim).

### DIFF
--- a/wikicurses/main.py
+++ b/wikicurses/main.py
@@ -217,6 +217,10 @@ class Ex(urwid.Edit):
             self.edit_pos = len(match)
         elif key == 'enter':
             if self.mode == 'ex':
+                matches = [i for i in cmds if i.startswith(self.edit_text)]
+                match = tabComplete(self.edit_text, matches)
+                self.edit_text = match
+
                 processCmd(*self.edit_text.split())
             if self.mode == 'search':
                 self.highlightText(self.edit_text)


### PR DESCRIPTION
Originally I went with the following:

```
if self.mode == 'ex':
    matches = [i for i in cmds if i.startswith(self.edit_text)]

    if len(matches) == 1:
        processCmd(matches[0])
    else:
        processCmd(*self.edit_text.split())
```

Which worked, but I quickly realised I could just copy your tab completion code verbatim with better results (more cases covered).

Admittedly not extensively tested so let me know if it's broken. It seems to work just fine for me though!
